### PR TITLE
Add override feature to process admin

### DIFF
--- a/joeflow/forms.py
+++ b/joeflow/forms.py
@@ -1,0 +1,39 @@
+from django import forms
+from django.utils.translation import gettext_lazy as t
+
+from . import models
+
+
+class OverrideForm(forms.ModelForm):
+    next_tasks = forms.MultipleChoiceField(
+        label=t("Next tasks"), choices=[], required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["next_tasks"].choices = [
+            (name, name) for name in dict(self._meta.model.get_nodes()).keys()
+        ]
+
+    def get_next_task_nodes(self):
+        names = self.cleaned_data["next_tasks"]
+        for name in names:
+            yield self._meta.model.get_node(name)
+
+    def start_next_tasks(self, user=None):
+        active_tasks = list(self.instance.task_set.filter(completed=None))
+        for task in active_tasks:
+            task.cancel(user)
+        if active_tasks:
+            parent_tasks = active_tasks
+        else:
+            try:
+                parent_tasks = [self.instance.task_set.latest()]
+            except models.Task.DoesNotExist:
+                parent_tasks = []
+        override_task = self.instance.task_set.create(
+            name="override", type=models.Task.HUMAN,
+        )
+        override_task.parent_task_set.set(parent_tasks)
+        override_task.finish(user=user)
+        override_task.start_next_tasks(next_nodes=self.get_next_task_nodes())

--- a/joeflow/utils.py
+++ b/joeflow/utils.py
@@ -5,6 +5,7 @@ import types
 def get_processes() -> types.GeneratorType:
     """Return all registered processes."""
     from django.apps import apps
+
     from .models import Process
 
     apps.check_models_ready()

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,63 @@
+from joeflow import forms
+from tests.testapp.models import SimpleProcess
+
+
+class TestOverrideForm:
+    def test_get_next_task_nodes(self):
+        class SimpleProcessForm(forms.OverrideForm):
+            class Meta:
+                model = SimpleProcess
+                fields = "__all__"
+
+        form = SimpleProcessForm({"next_tasks": ["end"]})
+        assert form.is_valid()
+        assert list(form.get_next_task_nodes()) == [SimpleProcess.end]
+
+    def test_start_next_tasks(self, db, admin_user):
+        process = SimpleProcess.start_method()
+        assert process.task_set.scheduled().exists()
+
+        class SimpleProcessForm(forms.OverrideForm):
+            class Meta:
+                model = SimpleProcess
+                fields = "__all__"
+
+        form = SimpleProcessForm({"next_tasks": ["end"]}, instance=process)
+        assert form.is_valid()
+        form.start_next_tasks()
+
+        assert process.task_set.scheduled()[0].name == "end"
+
+    def test_start_next_tasks__user(self, db, admin_user):
+        process = SimpleProcess.start_method()
+        assert process.task_set.scheduled().exists()
+
+        class SimpleProcessForm(forms.OverrideForm):
+            class Meta:
+                model = SimpleProcess
+                fields = "__all__"
+
+        form = SimpleProcessForm({"next_tasks": ["end"]}, instance=process)
+        assert form.is_valid()
+        form.start_next_tasks(admin_user)
+
+        assert process.task_set.canceled()[0].completed_by_user == admin_user
+        assert (
+            process.task_set.filter(name="override")[0].completed_by_user == admin_user
+        )
+        assert process.task_set.filter(name="override")[0].status == "succeeded"
+
+    def test_start_next_tasks__no_next_task(self, db, admin_user):
+        process = SimpleProcess.start_method()
+        assert process.task_set.scheduled().exists()
+
+        class SimpleProcessForm(forms.OverrideForm):
+            class Meta:
+                model = SimpleProcess
+                fields = "__all__"
+
+        form = SimpleProcessForm({"next_tasks": []}, instance=process)
+        assert form.is_valid()
+        form.start_next_tasks()
+
+        assert not process.task_set.scheduled().exists()


### PR DESCRIPTION
Django's MVC patter establishes the following dependecy graph:
Model -> Froms -> Views -> URLs

Having the workflow be a model will cause a dependecy loop. It is
best to have the workflow be isloated and depend on all privious
modules and only be imported by the urls module.