### PR TITLE
Get tutorial working

### DIFF
--- a/docs/tutorial/workflow.rst
+++ b/docs/tutorial/workflow.rst
@@ -56,15 +56,15 @@ Next we add the behavior:
         start = tasks.StartView(fields=['user'])
 
         def has_user(self, task):
-            if self.object.user_id is None:
+            if self.user_id is None:
                 return [self.end]
             else:
                 return [self.send_welcome_email]
 
         def send_welcome_email(self, task):
-            self.object.user.email_user(
+            self.user.email_user(
                 subject='Welcome',
-                message='Hello %s!' % self.object.user.get_short_name(),
+                message='Hello %s!' % self.user.get_short_name(),
             )
 
         def end(self, task):

--- a/joeflow/runner/celery.py
+++ b/joeflow/runner/celery.py
@@ -32,7 +32,7 @@ def _celery_task_runner(self, task_pk, workflow_pk):
         try:
             logger.info("Executing %r", task)
             node = task.node
-            with_task = getattr(node, "with_task", False)
+            with_task = getattr(node, "with_task", True)
             kwargs = {}
             if with_task:
                 kwargs["task"] = task


### PR DESCRIPTION
Hello, I'm following [the tutorial](https://joeflow.readthedocs.io/en/1.0.0/tutorial/workflow.html) and machine tasks all fail in celery

Environment:

joeflow==1.0.0
celery==4.4.0
Django==3.0.8

1. The task functions require a `with_task` attribute for some reason, without it you'll get the following error:

```
[2020-09-26 16:58:45,108: INFO/ForkPoolWorker-3] Executing <Task: has_user (14)>
[2020-09-26 16:58:45,115: ERROR/ForkPoolWorker-3] Execution of <Task: has_user (14)> failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/joeflow/runner/celery.py", line 40, in _celery_task_runner
    result = node(workflow, **kwargs)
TypeError: has_user() missing 1 required positional argument: 'task'
[2020-09-26 16:58:45,121: INFO/ForkPoolWorker-3] Task joeflow.runner.celery._celery_task_runner[35944c6a-6638-40de-93ec-d5922224d523] succeeded in 0.03581299999495968s: None
```

It stems from [this line](https://github.com/codingjoe/joeflow/blob/master/joeflow/runner/celery.py#L35), changing the default to True would fix it 

`with_task = getattr(node, "with_task", True)`

What is the reasoning behind this?

2. The task functions (i.e. `has_user`) incorrectly has `self.object.user_id` when it should just be `self.user_id`

This PR has both these changes