### PR TITLE
Move task creation into form_valid

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,17 @@
+from django.urls import reverse
+
+from .testapp import models
+
+
+class TestTaskViewMixin:
+    def test_create_task__form_errors(self, db, admin_client, admin_user):
+        url = reverse("shippingworkflow:checkout")
+        response = admin_client.post(
+            url, data={"shipping_address": 123, "email": "not a email"}
+        )
+        assert response.status_code == 200
+        assert response.context_data["form"].errors == {
+            "email": ["Enter a valid email address."]
+        }
+
+        assert models.Shipment.objects.count() == 0


### PR DESCRIPTION
Fixes a bug where form errors were shadowed by a failing task creating.