### PR TITLE
Changed task config to allow unlimited retries when task returns False

### DIFF
--- a/joeflow/runner/celery.py
+++ b/joeflow/runner/celery.py
@@ -16,6 +16,7 @@ __all__ = ["task_runner"]
 @shared_task(
     bind=True,
     ignore_results=True,
+    max_retries=None,
     autoretry_for=(OperationalError,),
     retry_backoff=True,
 )


### PR DESCRIPTION
When a task returns False, celery by default retries the task 3 times. After that it cancels the process. By changing max_retries to None it removes the retry limit.