### PR TITLE
Limit dramatiq version to 1.12 satisfy test suite

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ reversion =
 celery =
     celery>=4.2.0
 dramatiq =
-    dramatiq
+    dramatiq<=1.12.0
     django_dramatiq
 docs =
     celery>=4.2.0


### PR DESCRIPTION
The latest dramatiq version changed how they pick up tasks and
queues more than expected. We wait if those incompatibilties are
fixed in future versions.
