### PR TITLE
Pin django-dramatiq instead of dramatiq version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ docs = [
   "celery>=4.2.0",
   "django-reversion",
   "dramatiq",
-  "django_dramatiq",
+  "django_dramatiq<=0.10.0",
   "redis",
 ]
 reversion = [
@@ -76,8 +76,8 @@ celery = [
   "celery>=4.2.0",
 ]
 dramatiq = [
-  "dramatiq<=1.12.0",
-  "django_dramatiq",
+  "dramatiq",
+  "django_dramatiq<=0.10.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
I believe, the core problem was in django_dramatiq package:
https://github.com/Bogdanp/django_dramatiq/issues/123
Version 0.11 is not fully uploaded to PyPI or there is a bug in that version.

Also, there are no incompatibility issues raised in dramatiq repo:
https://github.com/Bogdanp/dramatiq/issues

Thus, I am changing pins in this PR to freeze django-dramatiq package.

@codingjoe WDYT?