### PR TITLE
Unpin django-dramatiq version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ docs = [
   "celery>=4.2.0",
   "django-reversion",
   "dramatiq",
-  "django_dramatiq<=0.10.0",
+  "django_dramatiq",
   "redis",
 ]
 reversion = [


### PR DESCRIPTION
Follow up to https://github.com/codingjoe/joeflow/pull/58
Issues mentioned were fixed in the latest django-dramatiq version, 0.11.2.
So it should work just fine now, we can unpin it.
