### PR TITLE
improve logging readability for Dramatiq

### DIFF
--- a/joeflow/runner/dramatiq.py
+++ b/joeflow/runner/dramatiq.py
@@ -57,7 +57,7 @@ def _dramatiq_task_runner(task_pk, workflow_pk, retries=0):
         else:
             if result is False:
                 _dramatiq_task_runner.logger.info("%r returned False, retrying …", task)
-                raise RetryError("%r returned False, retrying …" % task)
+                raise RetryError("Task returned False, retrying …")
             elif result is True:
                 result = None
             _dramatiq_task_runner.logger.info("%r completed successfully, starting next tasks: %s", task, result)

--- a/joeflow/runner/dramatiq.py
+++ b/joeflow/runner/dramatiq.py
@@ -10,9 +10,7 @@ from ..contrib.reversion import with_reversion
 logger = logging.getLogger(__name__)
 
 
-def task_runner(
-    *, task_pk, workflow_pk, countdown=None, eta=None, retries=0
-):
+def task_runner(*, task_pk, workflow_pk, countdown=None, eta=None, retries=0):
     """Schedule asynchronous machine task using celery."""
     _dramatiq_task_runner.send_with_options(
         args=(task_pk, workflow_pk),
@@ -34,9 +32,7 @@ class RetryError(dramatiq.errors.Retry):
 def _dramatiq_task_runner(task_pk, workflow_pk, retries=0):
     Task = apps.get_model("joeflow", "Task")
     with transaction.atomic():
-        task = Task.objects.select_for_update().get(
-            pk=task_pk, completed=None
-        )
+        task = Task.objects.select_for_update().get(pk=task_pk, completed=None)
 
         workflow = (
             task.content_type.model_class()
@@ -60,9 +56,7 @@ def _dramatiq_task_runner(task_pk, workflow_pk, retries=0):
             logger.exception("Execution of %r failed", task)
         else:
             if result is False:
-                _dramatiq_task_runner.logger.info(
-                    "%r returned False, retrying …", task
-                )
+                _dramatiq_task_runner.logger.info("%r returned False, retrying …", task)
                 raise RetryError("Task returned False, retrying …")
             elif result is True:
                 result = None

--- a/joeflow/runner/dramatiq.py
+++ b/joeflow/runner/dramatiq.py
@@ -56,7 +56,7 @@ def _dramatiq_task_runner(task_pk, workflow_pk, retries=0):
             logger.exception("Execution of %r failed", task)
         else:
             if result is False:
-                logger.info("%r returned False, retrying …", task)
+                _dramatiq_task_runner.logger.info("%r returned False, retrying …", task)
                 raise RetryError("%r returned False, retrying …" % task)
             elif result is True:
                 result = None

--- a/joeflow/runner/dramatiq.py
+++ b/joeflow/runner/dramatiq.py
@@ -60,6 +60,6 @@ def _dramatiq_task_runner(task_pk, workflow_pk, retries=0):
                 raise RetryError("%r returned False, retrying …" % task)
             elif result is True:
                 result = None
-            logger.info("%r completed successfully, starting next tasks: %s", task, result)
+            _dramatiq_task_runner.logger.info("%r completed successfully, starting next tasks: %s", task, result)
             task.start_next_tasks(next_nodes=result)
             task.finish()

--- a/joeflow/runner/dramatiq.py
+++ b/joeflow/runner/dramatiq.py
@@ -19,7 +19,7 @@ def task_runner(*, task_pk, workflow_pk, countdown=None, eta=None, retries=0):
     )
 
 
-class RetryError(Exception):
+class RetryError(dramatiq.errors.Retry):
     """Raised to retry a task if the task result is ``False``."""
 
     pass

--- a/joeflow/runner/dramatiq.py
+++ b/joeflow/runner/dramatiq.py
@@ -56,10 +56,10 @@ def _dramatiq_task_runner(task_pk, workflow_pk, retries=0):
             logger.exception("Execution of %r failed", task)
         else:
             if result is False:
-                logger.info("Task returned False, retrying …")
-                raise RetryError("Task returned False, retrying …")
+                logger.info("%r returned False, retrying …", task)
+                raise RetryError("%r returned False, retrying …" % task)
             elif result is True:
                 result = None
-            logger.info("Task completed successful, starting next tasks: %s", result)
+            logger.info("%r completed successfully, starting next tasks: %s", task, result)
             task.start_next_tasks(next_nodes=result)
             task.finish()

--- a/joeflow/runner/dramatiq.py
+++ b/joeflow/runner/dramatiq.py
@@ -10,7 +10,9 @@ from ..contrib.reversion import with_reversion
 logger = logging.getLogger(__name__)
 
 
-def task_runner(*, task_pk, workflow_pk, countdown=None, eta=None, retries=0):
+def task_runner(
+    *, task_pk, workflow_pk, countdown=None, eta=None, retries=0
+):
     """Schedule asynchronous machine task using celery."""
     _dramatiq_task_runner.send_with_options(
         args=(task_pk, workflow_pk),
@@ -32,7 +34,9 @@ class RetryError(dramatiq.errors.Retry):
 def _dramatiq_task_runner(task_pk, workflow_pk, retries=0):
     Task = apps.get_model("joeflow", "Task")
     with transaction.atomic():
-        task = Task.objects.select_for_update().get(pk=task_pk, completed=None)
+        task = Task.objects.select_for_update().get(
+            pk=task_pk, completed=None
+        )
 
         workflow = (
             task.content_type.model_class()
@@ -56,10 +60,16 @@ def _dramatiq_task_runner(task_pk, workflow_pk, retries=0):
             logger.exception("Execution of %r failed", task)
         else:
             if result is False:
-                _dramatiq_task_runner.logger.info("%r returned False, retrying …", task)
+                _dramatiq_task_runner.logger.info(
+                    "%r returned False, retrying …", task
+                )
                 raise RetryError("Task returned False, retrying …")
             elif result is True:
                 result = None
-            _dramatiq_task_runner.logger.info("%r completed successfully, starting next tasks: %s", task, result)
+            _dramatiq_task_runner.logger.info(
+                "%r completed successfully, starting next tasks: %s",
+                task,
+                result,
+            )
             task.start_next_tasks(next_nodes=result)
             task.finish()


### PR DESCRIPTION
by making `RetryError` inherit from `dramatiq.errors.Retry`, we can avoid having Dramatiq log a stack trace every time a task returns False.   (see https://github.com/Bogdanp/dramatiq/issues/469)

I also changed a few of the log message so that we know which task returned False or completed successfully.
